### PR TITLE
Enable SSL via PG_SSL for Neon; prefer DATABASE_URL when present

### DIFF
--- a/db/dbConfig.js
+++ b/db/dbConfig.js
@@ -1,9 +1,23 @@
 const pgp = require("pg-promise")();
 require("dotenv").config();
 
-const { DATABASE_URL, PG_HOST, PG_PORT, PG_DATABASE, PG_USER, PG_PASSWORD } =
-  process.env;
+const {
+  DATABASE_URL,
+  PG_HOST,
+  PG_PORT,
+  PG_DATABASE,
+  PG_USER,
+  PG_PASSWORD,
+  PG_SSL,
+} = process.env;
+
 // https://github.com/vitaly-t/pg-promise/wiki/Connection-Syntax#configuration-object
+// Prefer DATABASE_URL when provided. Otherwise, fall back to discrete PG_* vars.
+// Some managed Postgres providers (e.g., Neon) require TLS. Enable SSL when either
+// using a URL (always) or when PG_SSL is truthy ("true"/"1").
+const shouldUseManualSsl =
+  String(PG_SSL || "").toLowerCase() === "true" || PG_SSL === "1";
+
 const cn = DATABASE_URL
   ? {
       connectionString: DATABASE_URL,
@@ -18,13 +32,18 @@ const cn = DATABASE_URL
       database: PG_DATABASE,
       user: PG_USER,
       password: PG_PASSWORD,
+      ...(shouldUseManualSsl
+        ? {
+            ssl: {
+              rejectUnauthorized: false,
+            },
+          }
+        : {}),
     };
 
 // alt from express docs
 // var db = pgp('postgres://username:password@host:port/database')
 
 const db = pgp(cn);
-
-// console.log(cn);
 
 module.exports = db;


### PR DESCRIPTION
- Enabled SSL when using discrete PG_* vars via new PG_SSL toggle
- Continued SSL for DATABASE_URL connections
- Preferred DATABASE_URL when present; fallback to PG_* config
- Improved Neon compatibility and reliability of DB connections - this was changed because Render.com deletes the Database (DB) after 30 days but Neon DB remains 
- Created branch fix/db-ssl-config, committed db/dbConfig.js edits, and pushed to origin.
- Ready to open PR with concise description above.